### PR TITLE
Fix bugs which could result in core dump

### DIFF
--- a/src/app/http/ApiHandler.h
+++ b/src/app/http/ApiHandler.h
@@ -346,9 +346,11 @@ void ApiHandler::http_handler(beast::string_view /*doc_root*/,
                     config_ofs.close();
                     res.body() = ret_info;
                     res.result(403);
+                    config_ofs.close();
                     goto postcleanup;
                 }
 
+                config_ofs.close();
                 ret_info = "Change karst url successfully!Will use new karst url next era!";
                 p_log->info("%s Set karst url to:%s\n", ret_info.c_str(), karst_url.c_str());
                 res.body() = ret_info;
@@ -582,6 +584,11 @@ void ApiHandler::http_handler(beast::string_view /*doc_root*/,
                 res.body() = ret_json.dump();
                 res.result(200);
                 sealed_tree_map.unsafe_erase(org_root_hash_str);
+            }
+
+            if (p_new_path != NULL)
+            {
+                free(p_new_path);
             }
 
             goto postcleanup;

--- a/src/app/include/Resource.h
+++ b/src/app/include/Resource.h
@@ -10,3 +10,6 @@
 
 // For db data
 #define DB_SRD_INFO "srd_info"
+
+// For buffer pool
+#define BUFFER_AVAILABLE "buffer_available"

--- a/src/app/ocalls/OCalls.cpp
+++ b/src/app/ocalls/OCalls.cpp
@@ -261,6 +261,7 @@ crust_status_t ocall_get_file(const char *file_path, unsigned char **p_file, siz
         ocall_file_data = (uint8_t*)realloc(ocall_file_data, ocall_file_data_len);
         if (ocall_file_data == NULL)
         {
+            in.close();
             return CRUST_MALLOC_FAILED;
         }
     }
@@ -314,6 +315,7 @@ crust_status_t ocall_get_storage_file(const char *file_path, unsigned char **p_f
         _storage_buffer = (uint8_t*)realloc(_storage_buffer, _storage_buffer_len);
         if (_storage_buffer == NULL)
         {
+            in.close();
             return CRUST_MALLOC_FAILED;
         }
     }
@@ -689,11 +691,21 @@ void ocall_store_enclave_id_info(const char *info)
 
 /**
  * @description: Store enclave workload
- * @param wl -> Workload information
+ * @param data -> Workload information
+ * @param data_size -> Workload size
  */
-void ocall_store_workload(const char *wl)
+void ocall_store_workload(const char *data, size_t data_size, bool flag /*=true*/)
 {
-    set_g_enclave_workload(wl);
+    if (flag)
+    {
+        set_g_enclave_workload(std::string(data, data_size));
+    }
+    else
+    {
+        std::string str = get_g_enclave_workload();
+        str.append(data, data_size);
+        set_g_enclave_workload(str);
+    }
 }
 
 /**

--- a/src/app/ocalls/OCalls.h
+++ b/src/app/ocalls/OCalls.h
@@ -63,7 +63,7 @@ extern "C"
     void ocall_store_enclave_id_info(const char *info);
     void ocall_store_order_report(const char *p_order, size_t order_size);
     void ocall_store_identity(const char *id);
-    void ocall_store_workload(const char *wl);
+    void ocall_store_workload(const char *data, size_t data_size, bool flag = true);
     void ocall_store_workreport(const char *wr);
 
 #if defined(__cplusplus)

--- a/src/app/utils/BufferPool.h
+++ b/src/app/utils/BufferPool.h
@@ -6,6 +6,11 @@
 #include <vector>
 #include <string.h>
 #include <utility>
+#include <unistd.h>
+
+#include "Log.h"
+#include "Resource.h"
+#include "FormatUtils.h"
 
 class BufferPool
 {
@@ -20,8 +25,8 @@ private:
     BufferPool();
     uint32_t cur_index = 0;
     std::vector<std::pair<uint8_t*, size_t>> buffers;
-    size_t _buffer_size = 2*1024*1024;
-    uint32_t _buffer_num = 5;
+    size_t _buffer_size = 1*1024*1024;
+    uint32_t _buffer_num = 15;
 
 };
 

--- a/src/app/utils/FileUtils.cpp
+++ b/src/app/utils/FileUtils.cpp
@@ -293,6 +293,7 @@ std::vector<std::string> get_sub_folders_and_files(const char *path)
 
             dirs.push_back(std::string(ent->d_name));
         }
+        closedir(dir);
     }
 
     return dirs;

--- a/src/enclave/Enclave.config.xml
+++ b/src/enclave/Enclave.config.xml
@@ -1,8 +1,8 @@
 <EnclaveConfiguration>
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
-  <StackMaxSize>0x400000</StackMaxSize>
-  <HeapMaxSize>0x6000000</HeapMaxSize>
+  <StackMaxSize>0x2000000</StackMaxSize>
+  <HeapMaxSize>0x20000000</HeapMaxSize>
   <TCSNum>15</TCSNum>
   <TCSPolicy>0</TCSPolicy>
   <DisableDebug>0</DisableDebug>

--- a/src/enclave/Enclave.edl
+++ b/src/enclave/Enclave.edl
@@ -2,6 +2,7 @@ enclave {
     include "sgx_tcrypto.h"
     include "sgx_dh.h"
     include "sgx_tseal.h"
+    include "stdbool.h"
     include "MerkleTree.h"
     include "CrustStatus.h"
 	include "IASReport.h"
@@ -77,7 +78,7 @@ enclave {
         void ocall_store_order_report([in, size=order_size] const char *p_order, size_t order_size);
         void ocall_store_identity([in, string] const char *id);
         void ocall_store_enclave_id_info([in, string] const char *info);
-        void ocall_store_workload([in, string] const char *wl);
+        void ocall_store_workload([in, size=data_size] const char *data, size_t data_size, bool flag);
         void ocall_store_workreport([in, string] const char *wr);
     };
 };

--- a/src/enclave/identity/Identity.cpp
+++ b/src/enclave/identity/Identity.cpp
@@ -381,7 +381,7 @@ crust_status_t id_verify_iasreport(char **IASReport, size_t size)
     uint8_t *p_account_id_u = hex_string_to_bytes(chain_account_id.c_str(), chain_account_id.size());
     size_t account_id_u_len = chain_account_id.size() / 2;
     uint8_t *org_data, *p_org_data = NULL;
-    size_t org_data_len = 0;
+    uint32_t org_data_len = 0;
 
 
     // ----- Verify IAS signature ----- //
@@ -602,22 +602,26 @@ crust_status_t id_verify_iasreport(char **IASReport, size_t size)
 
 cleanup:
     if (pkey != NULL)
-    {
         EVP_PKEY_free(pkey);
-    }
+
     cert_stack_free(stack);
-    free(certar);
+
+    if (certar != NULL)
+        free(certar);
+
     for (i = 0; i < count; ++i)
     {
         X509_free(certvec[i]);
     }
 
-    free(sig);
-    free(iasQuote);
+    if (sig != NULL)
+        free(sig);
+
+    if (iasQuote != NULL)
+        free(iasQuote);
+
     if (ecc_state != NULL)
-    {
         sgx_ecc256_close_context(ecc_state);
-    }
 
     if (p_org_data != NULL)
         free(p_org_data);
@@ -897,36 +901,31 @@ crust_status_t id_store_metadata()
     sgx_thread_mutex_lock(&g_metadata_mutex);
 
     // Get original metadata
+    Workload *wl = Workload::get_instance();
     crust_status_t crust_status = CRUST_SUCCESS;
-    json::JSON meta_json;
-    size_t meta_len = 0;
-    uint8_t *p_meta = NULL;
     std::string hex_id_key_str = hexstring_safe(&id_key_pair, sizeof(id_key_pair));
-    id_get_metadata(meta_json, false);
 
     // ----- Store metadata ----- //
-    meta_json[ID_WORKLOAD] = Workload::get_instance()->serialize_srd();
-    meta_json[ID_KEY_PAIR] = hex_id_key_str;
-    meta_json[ID_REPORT_SLOG] = report_slot;
-    meta_json[ID_CHAIN_ACCOUNT_ID] = g_chain_account_id;
-    std::string meta_str = meta_json.dump();
-    meta_len = meta_str.size() + strlen(TEE_PRIVATE_TAG);
-    p_meta = (uint8_t*)enc_malloc(meta_len);
-    if (p_meta == NULL)
-    {
-        crust_status = CRUST_MALLOC_FAILED;
-        goto cleanup;
-    }
-    memset(p_meta, 0, meta_len);
-    memcpy(p_meta, TEE_PRIVATE_TAG, strlen(TEE_PRIVATE_TAG));
-    memcpy(p_meta + strlen(TEE_PRIVATE_TAG), meta_str.c_str(), meta_str.size());
-    crust_status = persist_set(ID_METADATA, p_meta, meta_len);
+    std::string meta_str(TEE_PRIVATE_TAG);
+    meta_str.append("{");
+    // Append srd
+    meta_str.append("\"").append(ID_WORKLOAD).append("\":")
+        .append(wl->serialize_srd()).append(",");
+    // Append id key pair
+    meta_str.append("\"").append(ID_KEY_PAIR).append("\":")
+        .append("\"").append(hex_id_key_str).append("\",");
+    // Append report slot
+    meta_str.append("\"").append(ID_REPORT_SLOT).append("\":")
+        .append("\"").append(std::to_string(report_slot)).append("\",");
+    // Append chain account id
+    meta_str.append("\"").append(ID_CHAIN_ACCOUNT_ID).append("\":")
+        .append("\"").append(g_chain_account_id).append("\",");
+    // Append files
+    meta_str.append("\"").append(ID_FILE).append("\":")
+        .append(wl->serialize_file());
+    meta_str.append("}");
 
-
-cleanup:
-
-    if (p_meta != NULL)
-        free(p_meta);
+    crust_status = persist_set(ID_METADATA, reinterpret_cast<const uint8_t *>(meta_str.c_str()), meta_str.size());
 
     sgx_thread_mutex_unlock(&g_metadata_mutex);
 
@@ -996,7 +995,7 @@ crust_status_t id_restore_metadata()
     memcpy(&id_key_pair, p_id_key, sizeof(id_key_pair));
     free(p_id_key);
     // Restore report slot
-    report_slot = meta_json[ID_REPORT_SLOG].ToInt();
+    report_slot = meta_json[ID_REPORT_SLOT].ToInt();
     // Restore chain account id
     g_chain_account_id = meta_json[ID_CHAIN_ACCOUNT_ID].ToString();
 
@@ -1044,14 +1043,12 @@ crust_status_t id_set_chain_account_id(const char *account_id, size_t len)
         return CRUST_DOUBLE_SET_VALUE;
     }
 
-    char *buffer = (char *)enc_malloc(len);
-    if (buffer == NULL)
+    if (account_id == NULL)
     {
-        return CRUST_MALLOC_FAILED;
+        return CRUST_UNEXPECTED_ERROR;
     }
-    memset(buffer, 0, len);
-    memcpy(buffer, account_id, len);
-    g_chain_account_id = string(buffer, len);
+
+    g_chain_account_id = string(account_id, len);
     g_is_set_account_id = true;
 
     return CRUST_SUCCESS;
@@ -1082,7 +1079,6 @@ size_t id_get_report_slot()
 void id_set_report_slot(size_t new_report_slot)
 {
     report_slot = new_report_slot;
-    id_metadata_set_or_append(ID_REPORT_SLOG, std::to_string(report_slot));
 }
 
 /**

--- a/src/enclave/identity/Identity.h
+++ b/src/enclave/identity/Identity.h
@@ -88,10 +88,8 @@ crust_status_t id_metadata_set_or_append(const char *key, T val,
     }
 
     std::string key_str(key);
-    std::string meta_str;
+    std::string meta_str(TEE_PRIVATE_TAG);
     json::JSON meta_json;
-    size_t meta_len = 0;
-    uint8_t *p_meta = NULL;
     crust_status_t crust_status = CRUST_SUCCESS;
     id_get_metadata(meta_json, false);
 
@@ -123,19 +121,8 @@ crust_status_t id_metadata_set_or_append(const char *key, T val,
         crust_status = CRUST_UNEXPECTED_ERROR;
         goto cleanup;
     }
-    meta_str = meta_json.dump();
-    meta_len = meta_str.size() + strlen(TEE_PRIVATE_TAG);
-    p_meta = (uint8_t*)enc_malloc(meta_len);
-    if (p_meta == NULL)
-    {
-        crust_status = CRUST_MALLOC_FAILED;
-        goto cleanup;
-    }
-    memset(p_meta, 0, meta_len);
-    memcpy(p_meta, TEE_PRIVATE_TAG, strlen(TEE_PRIVATE_TAG));
-    memcpy(p_meta + strlen(TEE_PRIVATE_TAG), meta_str.c_str(), meta_str.size());
-    crust_status = persist_set(ID_METADATA, p_meta, meta_len);
-    free(p_meta);
+    meta_str.append(meta_json.dump());
+    crust_status = persist_set(ID_METADATA, reinterpret_cast<const uint8_t *>(meta_str.c_str()), meta_str.size());
 
 cleanup:
 

--- a/src/enclave/include/Parameter.h
+++ b/src/enclave/include/Parameter.h
@@ -5,12 +5,15 @@
 
 #define LEAF_SEPARATOR  "+leaf+"
 
+// For persistence
+#define OCALL_STORE_THRESHOLD 4194304 /* 4*1024*1024 */
+
 // For enclave metadata
 #define ID_METADATA "metadata"
 #define ID_FILE "files"
 #define ID_WORKLOAD "workload"
 #define ID_KEY_PAIR "id_key_pair"
-#define ID_REPORT_SLOG "report_slot"
+#define ID_REPORT_SLOT "report_slot"
 #define ID_CHAIN_ACCOUNT_ID "chain_account_id"
 
 // For meaningful file
@@ -66,9 +69,16 @@
 #define WL_FILE_OLD_HASH "old_hash"
 #define WL_FILE_OLD_SIZE "old_size"
 
+// For ocalls
+#define PERSIST_SUM "persist_sum"
+#define PERSIST_SIZE "persist_size"
+
 // Basic parameters
 #define HASH_LENGTH 32
 #define ENC_MAX_THREAD_NUM  15
 #define ENCLAVE_MALLOC_TRYOUT 3
+
+// For buffer pool
+#define BUFFER_AVAILABLE "buffer_available"
 
 #endif /* !_ENCLAVE_RESOURCE_H_ */

--- a/src/enclave/report/Report.cpp
+++ b/src/enclave/report/Report.cpp
@@ -94,13 +94,13 @@ crust_status_t get_signed_work_report(const char *block_hash, size_t block_heigh
     {
         g_hashs_num += it.second.size();
     }
-    unsigned char *hashs = (unsigned char *)enc_malloc(g_hashs_num * HASH_LENGTH);
+    uint8_t *hashs = (uint8_t *)enc_malloc(g_hashs_num * HASH_LENGTH);
     if (hashs == NULL)
     {
         log_err("Malloc memory failed!\n");
         return CRUST_MALLOC_FAILED;
     }
-    size_t hashs_len = 0;
+    uint32_t hashs_len = 0;
     for (auto it : wl->srd_path2hashs_m)
     {
         for (auto g_hash : it.second)
@@ -118,7 +118,7 @@ crust_status_t get_signed_work_report(const char *block_hash, size_t block_heigh
     else
     {
         srd_workload = (hashs_len / HASH_LENGTH) * 1024 * 1024 * 1024;
-        sgx_sha256_msg(hashs, (uint32_t)hashs_len, &srd_root);
+        sgx_sha256_msg(hashs, hashs_len, &srd_root);
     }
     free(hashs);
     sgx_thread_mutex_unlock(&g_srd_mutex);
@@ -249,7 +249,7 @@ crust_status_t get_signed_order_report()
 {
     sgx_status_t sgx_status = SGX_SUCCESS;
     crust_status_t crust_status = CRUST_SUCCESS;
-    size_t org_data_len = 0;
+    uint32_t org_data_len = 0;
     uint8_t *org_data = NULL;
     uint8_t *p_org_data = NULL;
     std::string order_str;
@@ -313,7 +313,7 @@ crust_status_t get_signed_order_report()
     org_data += files_str.size();
     // Copy random
     memcpy(org_data, random_str.c_str(), random_str.size());
-    sgx_status = sgx_ecdsa_sign(p_org_data, (uint32_t)org_data_len,
+    sgx_status = sgx_ecdsa_sign(p_org_data, org_data_len,
             &id_key_pair.pri_key, &ecc_signature, ecc_state);
     if (SGX_SUCCESS != sgx_status)
     {

--- a/src/enclave/utils/EUtils.h
+++ b/src/enclave/utils/EUtils.h
@@ -32,6 +32,8 @@ namespace json
 /* The length of hash */
 #define HASH_LENGTH 32
 
+typedef sgx_status_t (*p_ocall_store)(const char *data, size_t data_size, bool flag);
+
 
 #if defined(__cplusplus)
 extern "C"
@@ -76,6 +78,7 @@ void *enc_malloc(size_t size);
 void *enc_realloc(void *p, size_t size);
 void remove_char(std::string &data, char c);
 void replace(std::string &data, std::string org_str, std::string det_str);
+void store_large_data(const char *data, size_t data_size, p_ocall_store p_func);
 
 #if defined(__cplusplus)
 }

--- a/src/enclave/workload/Workload.h
+++ b/src/enclave/workload/Workload.h
@@ -31,9 +31,10 @@ public:
     static Workload *get_instance();
     ~Workload();
     std::string get_workload(void);
-    json::JSON serialize_srd(bool locked = true);
+    std::string serialize_srd(bool locked = true);
+    std::string serialize_file(bool locked =true);
     crust_status_t restore_srd(json::JSON g_hashs);
-    crust_status_t get_srd_info(sgx_sha256_hash_t *srd_root_out, size_t *srd_workload_out, json::JSON &md_json);
+    crust_status_t get_srd_info(sgx_sha256_hash_t *srd_root_out, uint64_t *srd_workload_out, json::JSON &md_json);
     void clean_data();
 
     void add_new_file(json::JSON file);


### PR DESCRIPTION
1. Fix memory overflow bug
2. ocall_persist_xxx related function: Store large data separately
3. Store workload large data separately
4. Change metadata mechanism: just use metadata to show info and restore
5. Adjust stackMaxSize to 32MB
6. Adjust heapMaxSize to 512MB
7. Close opened file handler