### PR TITLE
Fix memory leak

### DIFF
--- a/src/enclave/storage/Storage.cpp
+++ b/src/enclave/storage/Storage.cpp
@@ -59,6 +59,10 @@ crust_status_t storage_seal_file_start(const char *root, const char *root_b58)
     wl->pending_files_um[root_cid][FILE_BLOCKS][root_cid_b58].AddNum(1);
     sl.unlock();
 
+    // Delete previous left data
+    crust_status_t del_ret = CRUST_SUCCESS;
+    ocall_delete_ipfs_file(&del_ret, root);
+
     // Add info in workload spec
     wl->set_file_spec(FILE_STATUS_PENDING, 1);
 

--- a/src/enclave/utils/EUtils.cpp
+++ b/src/enclave/utils/EUtils.cpp
@@ -353,6 +353,7 @@ crust_status_t seal_data_mrenclave(const uint8_t *p_src, size_t src_len,
     {
         log_err("Seal data failed!Error code:%lx\n", sgx_status);
         crust_status = CRUST_SEAL_DATA_FAILED;
+        free(*p_sealed_data);
         *p_sealed_data = NULL;
     }
 
@@ -863,6 +864,7 @@ crust_status_t unseal_data_mrsigner(const sgx_sealed_data_t *data,
     if (SGX_SUCCESS != sgx_status)
     {
         log_err("SGX unseal failed! Internal error:%lx\n", sgx_status);
+        free(*p_decrypted_data);
         return CRUST_UNSEAL_DATA_FAILED;
     }
 


### PR DESCRIPTION
1. Delete old file before sealing the new with same cid
2. Fix seal and unseal data memory leak